### PR TITLE
Fix: Wrong variable in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Eine Variable im release Workflow ist falsch, weshalb er nicht funktioniert.