### PR TITLE
Fix: Add client to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 ### Client ###
-client/
+client/node_modules
+client/build


### PR DESCRIPTION
Add the `client/node_modules` and `client/build` folders to .dockerignore to make the build faster
