### PR TITLE
Fix: Submodule missing in workflows

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v2

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          submodules: true
       
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Fixes #65 
Damit wird das Submodule beim Clonen initialisiert. Das sollte den Fehler beheben.