### PR TITLE
Fix: remove allOf for descriptions

### DIFF
--- a/src/main/resources/api/swagger.yaml
+++ b/src/main/resources/api/swagger.yaml
@@ -5,7 +5,7 @@ info:
     
     A reference implementation is available on [Github](https://github.com/Eistbaren/frontend)
 
-  version: 1.0.3
+  version: 1.0.4
   title: "Reservation Bear API"
 
 basePath: /api/


### PR DESCRIPTION
Das allOf macht hier das Generieren des TypeScript Clients kaputt und muss deshalb raus. Siehe https://github.com/Eistbaren/client/pull/38