### PR TITLE
fix: build only working the 2nd time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:jdk17 as build
 WORKDIR /workspace
 COPY . .
 
-RUN gradle bootJar && gradle bootJar
+RUN gradle bootJar
 
 FROM openjdk:17-jdk-alpine
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,20 +57,18 @@ task submodulesUpdate(type: Exec) {
     group 'Build Setup'
 }
 
-npmInstall.dependsOn submodulesUpdate
+nodeSetup.dependsOn submodulesUpdate
 
-task copyReactBuildFiles {
+task copyReactBuildFiles(type: Copy) {
     description "Copies the build files from react to the desired location"
     dependsOn npm_run_build
-    copy {
-        project.build
-        from "client/build"
-        into "src/main/resources/static/dist"
-        includeEmptyDirs true
-    }
+    from "client/build"
+    into "src/main/resources/static/dist"
+    includeEmptyDirs true
     group "npm"
 }
 
+compileKotlin.dependsOn copyReactBuildFiles
 processResources.dependsOn copyReactBuildFiles
 
 clean.delete << file("client/node_modules")


### PR DESCRIPTION
`compileKotlin.dependsOn copyReactBuildFiles`
die Zeile sollte es gefixed haben, die anderen sind nur kosmetische Sachen.

Ich kann den Docker build bei mir lokal nicht builden weil gradle aus irgendeinem grund nicht die Jars aus dem Internet ziehen kann also mal schauen ob der jetzt durchkommt.