### PR TITLE
Add timeslots and fix inserts after comments

### DIFF
--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -4,8 +4,12 @@ values ('069f72db-2157-43de-8e88-21661b518200', 'Mensa Garching', 5.0, 2, 'hunge
 insert into RESTAURANT_LOCATION(ID, LAT, LON, RESTAURANT_ID)
 values ('069f72db-2157-43de-8e88-21661b518200', 48.267873, 11.672376, '069f72db-2157-43de-8e88-21661b518200');
 
+// 8-2 / 17-2 to fix the time zone;
 INSERT INTO TIMESLOT
-values ('069f72db-2157-43de-8e98-21661b518200', 0,0, '069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e98-21661b518200',
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (8 - 2),
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (17 - 2),
+        '069f72db-2157-43de-8e88-21661b518200');
 
 insert into restaurant_table(id, seats, restaurant_id)
 values ('069f72db-2157-43de-8e88-21661b518201', 3, '069f72db-2157-43de-8e88-21661b518200');
@@ -40,22 +44,44 @@ values ('069f72db-2157-43de-8e88-21661b518303', '/serverFile/serverImages/restau
 insert into IMAGE (ID, IMAGEURL)
 values ('069f72db-2157-43de-8e88-21661b518304', '/serverFile/serverImages/restaurant/mensa-innen-2.png');
 
-// https://www.mockaroo.com/
+// https://www.mockaroo.com/;
 insert into restaurant (ID, NAME, AVERAGE_RATING, PRICE_CATEGORY, WEBSITE)
 values ('069f72db-2157-43de-8e88-21661b518201', 'Cronin-Hagenes', 2, 2, 'www.tum.de');
+INSERT INTO TIMESLOT
+values ('069f72db-2157-43de-8e98-21661b518201',
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (11 - 2),
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (19 - 2),
+        '069f72db-2157-43de-8e88-21661b518201');
+insert into RESTAURANT_LOCATION(ID, LAT, LON, RESTAURANT_ID)
+values ('069f72db-2157-43de-8e88-21661b518201', 48.147154, 11.566124, '069f72db-2157-43de-8e88-21661b518201');
 
 insert into restaurant (ID, NAME, AVERAGE_RATING, PRICE_CATEGORY, WEBSITE)
 values ('069f72db-2157-43de-8e88-21661b518202', 'Schultz, Abshire and Yost', 3, 3, 'www.tum.de');
+INSERT INTO TIMESLOT
+values ('069f72db-2157-43de-8e98-21661b518202',
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (10 - 2),
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (18 - 2),
+        '069f72db-2157-43de-8e88-21661b518202');
 insert into RESTAURANT_LOCATION(ID, LAT, LON, RESTAURANT_ID)
 values ('069f72db-2157-43de-8e88-21661b518202', 48.147154, 11.586124, '069f72db-2157-43de-8e88-21661b518202');
 
 insert into restaurant (ID, NAME, AVERAGE_RATING, PRICE_CATEGORY, WEBSITE)
 values ('069f72db-2157-43de-8e88-21661b518203', 'Ferry-Steuber', 4, 1, 'www.tum.de');
+INSERT INTO TIMESLOT
+values ('069f72db-2157-43de-8e98-21661b518203',
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (15 - 2),
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (20 - 2),
+        '069f72db-2157-43de-8e88-21661b518203');
 insert into RESTAURANT_LOCATION(ID, LAT, LON, RESTAURANT_ID)
 values ('069f72db-2157-43de-8e88-21661b518203', 48.168154, 11.576124, '069f72db-2157-43de-8e88-21661b518203');
 
 insert into restaurant (ID, NAME, AVERAGE_RATING, PRICE_CATEGORY, WEBSITE)
 values ('069f72db-2157-43de-8e88-21661b518204', 'Balistreri-Quigley', 5, 2, 'www.google.de');
+INSERT INTO TIMESLOT
+values ('069f72db-2157-43de-8e98-21661b518204',
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (10 - 2),
+        DATEDIFF('SECOND', DATE '1970-01-01', CURRENT_DATE()) + 60 * 60 * (14 - 2),
+        '069f72db-2157-43de-8e88-21661b518204');
 insert into RESTAURANT_LOCATION(ID, LAT, LON, RESTAURANT_ID)
 values ('069f72db-2157-43de-8e88-21661b518204', 48.157154, 11.556124, '069f72db-2157-43de-8e88-21661b518204');
 
@@ -264,6 +290,8 @@ values ('069f72db-2157-43de-8e88-21661b518200', '069f72db-2157-43de-8e88-21661b5
 insert into RESTAURANT_IMAGES (RESTAURANT_ID, IMAGE_ID)
 values ('069f72db-2157-43de-8e88-21661b518200', '069f72db-2157-43de-8e88-21661b518304');
 insert into RESTAURANT_IMAGES (RESTAURANT_ID, IMAGE_ID)
+values ('069f72db-2157-43de-8e88-21661b518201', '069f72db-2157-43de-8e88-21661b518304');
+insert into RESTAURANT_IMAGES (RESTAURANT_ID, IMAGE_ID)
 values ('069f72db-2157-43de-8e88-21661b518202', '069f72db-2157-43de-8e88-21661b518302');
 insert into RESTAURANT_IMAGES (RESTAURANT_ID, IMAGE_ID)
 values ('069f72db-2157-43de-8e88-21661b518203', '069f72db-2157-43de-8e88-21661b518303');
@@ -274,24 +302,24 @@ values ('069f72db-2157-43de-8e88-21661b518204', '069f72db-2157-43de-8e88-21661b5
 insert into comment (id, rating, comment, name, restaurant_id)
 values ('069f72db-2157-43de-8e88-21661b518201', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518202', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518202', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518203', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518203', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518204', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518204', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518205', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518205', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518206', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518206', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518207', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518207', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518208', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518208', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518209', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518209', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518210', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518210', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518211', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518211', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');
 insert into comment (id, rating, comment, name, restaurant_id)
-values ('069f72db-2157-43de-8e88-21661b518212', 1, 'Super DB', 'DB-Admin','069f72db-2157-43de-8e88-21661b518200');
+values ('069f72db-2157-43de-8e88-21661b518212', 1, 'Super DB', 'DB-Admin', '069f72db-2157-43de-8e88-21661b518200');


### PR DESCRIPTION
Fügt die in #95 entfernten und neue Timeslots hinzu.

Da ich nun endlich draufbekommen bin, wieso die inserts nach Kommentaren nicht funktionieren, hab ich die auch gleich abgeändert.

Auf der Such-Seite sollten nun wieder die Öffnungszeiten angezeigt werden.
![image](https://user-images.githubusercontent.com/92096842/176914834-19b2417c-6baf-4dd6-8cdf-f78e197b2bfd.png)
 