### PR TITLE
Fix timeslot naming to time

### DIFF
--- a/src/main/kotlin/de/reservationbear/eist/controller/responseMapper/RestaurantTableMapper.kt
+++ b/src/main/kotlin/de/reservationbear/eist/controller/responseMapper/RestaurantTableMapper.kt
@@ -11,7 +11,7 @@ import java.util.*
  */
 data class RestaurantTableMapper(
 
-    @field:JsonProperty("timeslot") val timeslots: TimeslotMapper? = null,
+    @field:JsonProperty("time") val timeslots: TimeslotMapper? = null,
 
     @field:JsonProperty("reservedTables") val reservedTables: List<UUID?>? = null
 )


### PR DESCRIPTION
Müsste nun gefixt sein:
[http://localhost:8080/api/restaurant/069f72db-2157-43de-8e88-21661b518200/reservation?from=0&to=111111111111](
http://localhost:8080/api/restaurant/069f72db-2157-43de-8e88-21661b518200/reservation?from=0&to=111111111111)

Erwartet wird time statt timeslot als Benennung