### PR TITLE
Fix error with Random.NextInt by replacing with Math.random

### DIFF
--- a/src/main/kotlin/de/reservationbear/eist/confirmationmail/RegistrationMailPattern.kt
+++ b/src/main/kotlin/de/reservationbear/eist/confirmationmail/RegistrationMailPattern.kt
@@ -3,6 +3,7 @@ package de.reservationbear.eist.confirmationmail
 
 import org.springframework.stereotype.Service
 import java.util.*
+import kotlin.math.floor
 
 /**
  * Pattern for sending a registration mail
@@ -26,7 +27,7 @@ class RegistrationMailPattern(val mailSender: MailSender) {
         mailSender.send(
             mailAddress,
             buildEmail(name.split(" ")[0], link),
-            "${icons[Random().nextInt(0,icons.size)]} Confirmation of your reservation (${reservationId})",
+            "${icons[floor(Math.random() * icons.size).toInt()]} Confirmation of your reservation (${reservationId})",
             null
         )
     }


### PR DESCRIPTION
POST https://reservation-bear.de/api/reservation

{
"tables": [
"069f72db-2157-43de-8e88-21661b518201"
],
"time": {
"from": 1657029330,
"to": 1657029330
},
"userName": "Simon Okutan",
"userEmail": "[simon.ok@gmx.de](mailto:simon.ok@gmx.de)"
}

Dürfte jetzt auch im DockerImg keinen Fehler mehr werfen