### PR TITLE
Fix findReservationsInTimeframeOfRestaurant edge cases

### DIFF
--- a/src/main/kotlin/de/reservationbear/eist/db/repository/RestaurantRepository.kt
+++ b/src/main/kotlin/de/reservationbear/eist/db/repository/RestaurantRepository.kt
@@ -52,7 +52,7 @@ interface RestaurantRepository : JpaRepository<Restaurant, UUID> {
                 "AND re.reservationFrom < ?3)" +
                 ")",
 
-        countQuery = "SELECT DISTINCT re " +
+        countQuery = "SELECT count(DISTINCT re) " +
                 "FROM Restaurant r " +
                 "JOIN r.restaurantTables rt " +
                 "JOIN rt.reservation re " +


### PR DESCRIPTION
Nun sollten auch folgende Fälle funktionieren:
- sucheStart < reservierungStart && reservierungStart < sucheEnde
- sucheStart >= reservierungStart && reservierungEnde < sucheEnde
- sucheStart >= reservierungStart && reservierungEnde > sucheEnde